### PR TITLE
split method - more accurate description

### DIFF
--- a/lib/IPv6/Address.pm
+++ b/lib/IPv6/Address.pm
@@ -333,11 +333,12 @@ sub to_string {
 	return $_[0]->string();
 }
 
-=item C<split( exponent , target_length )>
+=item C<split( exponent )>
 
-Splits the address to the order of two of the number given as first argument.
-Example: if argument is 3, 2^3=8, address is split into 8 parts. The final parts
-have prefix length equal to the target_length specified in the second argument.
+Splits the address into subnets of the size (2^exponent) specified by the first argument.
+Example: if argument is 3, 2^3=8, the address to be splitted into 8 subnets. The final parts
+have prefix length equal to the address prefix length + exponent. An exponent should not exceed 128 together with the sum of an original prefix length.
+For example if a prefix len of address is 125 then an exponent can be up to 3.
 
 =cut
 sub split {


### PR DESCRIPTION
At first I did not understand the meaning of this method from the documentation, and at first I thought that the address was simply broken into pieces of exponent bits. But looking at the code, I realized that it is generally intended for another. Apparently this method was used to divide the networks into subnets a exponent bits additionally? Then my comment more accurately reflects the meaning IMHO.

And the target_length is not used in source. I think it's old removed variable. Please check up this!